### PR TITLE
Fix TestTime in test_zenweb_extensions so tests pass in any timezone

### DIFF
--- a/test/test_zenweb_extensions.rb
+++ b/test/test_zenweb_extensions.rb
@@ -20,14 +20,14 @@ end
 
 class TestTime < MiniTest::Unit::TestCase
   def test_date
-    assert_equal "1969-12-31",         Time.at(0).date
+    assert_equal "1969-12-31",         Time.new(1969,12,31,16,0).date
   end
 
   def test_datetime
-    assert_equal "1969-12-31 @ 16:00", Time.at(0).datetime
+    assert_equal "1969-12-31 @ 16:00", Time.new(1969,12,31,16,0).datetime
   end
 
   def test_time
-    assert_equal "16:00",              Time.at(0).time
+    assert_equal "16:00",              Time.new(1969,12,31,16,0).time
   end
 end


### PR DESCRIPTION
The TestTime tests failed for me in the UK, because I'm in a timezone where Time.at(0) is reported as being at the start of 1970, rather than the end of 1969.

I think the correct behaviour is to fix the test to match local time, rather than to fix the extensions to report a particular timezone. Therefore, the attached pull request should make the tests pass whatever the timezone by using Time.new(1969,12,31,16,0) in place of Time.at(0).

Hope it helps.

Tom
